### PR TITLE
fix(security): add XSS protection for address fields and relax city v…

### DIFF
--- a/Plugin/Customer/SanitizeAddressPlugin.php
+++ b/Plugin/Customer/SanitizeAddressPlugin.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Copyright (c) Address Zen
+ *
+ * Customer Address Sanitization Plugin
+ *
+ * This plugin intercepts customer address data and sanitizes the city field
+ * to prevent XSS attacks by stripping HTML/script tags.
+ *
+ * @package Addresszen_Lookup
+ * @author Address Zen <support@addresszen.com>
+ * @copyright Address Zen
+ * @license MIT https://opensource.org/licenses/MIT
+ * @link https://addresszen.com
+ */
+
+namespace Addresszen\Lookup\Plugin\Customer;
+
+use Magento\Customer\Model\Address;
+
+/**
+ * Plugin to sanitize customer address data
+ *
+ * Intercepts the setCity method to strip HTML tags and prevent XSS attacks.
+ */
+class SanitizeAddressPlugin
+{
+    /**
+     * Sanitize city field before setting it on customer address
+     *
+     * @param Address $subject The customer address object
+     * @param string|null $city The city value being set
+     * @return array Modified arguments for the original method
+     */
+    public function beforeSetCity(Address $subject, $city)
+    {
+        if ($city !== null && is_string($city)) {
+            $city = $this->sanitizeText($city);
+        }
+
+        return [$city];
+    }
+
+    /**
+     * Sanitize all address data before saving
+     *
+     * @param Address $subject The customer address object
+     * @return void
+     */
+    public function beforeBeforeSave(Address $subject)
+    {
+        // Sanitize city if it exists
+        $city = $subject->getCity();
+        if ($city !== null && is_string($city)) {
+            $subject->setCity($this->sanitizeText($city));
+        }
+
+        // Also sanitize other text fields
+        $street = $subject->getStreet();
+        if (is_array($street)) {
+            $sanitizedStreet = array_map(function($line) {
+                return is_string($line) ? $this->sanitizeText($line) : $line;
+            }, $street);
+            $subject->setStreet($sanitizedStreet);
+        }
+
+        // Sanitize company name
+        $company = $subject->getCompany();
+        if ($company !== null && is_string($company)) {
+            $subject->setCompany($this->sanitizeText($company));
+        }
+    }
+
+    /**
+     * Sanitize text by removing HTML tags and JavaScript
+     *
+     * @param string $text
+     * @return string
+     */
+    private function sanitizeText($text)
+    {
+        if (!is_string($text)) {
+            return $text;
+        }
+
+        // Remove script/style tags AND their content
+        $text = preg_replace('/<script\b[^>]*>(.*?)<\/script>/is', '', $text);
+        $text = preg_replace('/<style\b[^>]*>(.*?)<\/style>/is', '', $text);
+
+        // Strip all remaining HTML and PHP tags
+        $text = strip_tags($text);
+
+        // Remove any remaining JavaScript-like patterns
+        $text = preg_replace('/javascript:/i', '', $text);
+        $text = preg_replace('/on\w+\s*=/i', '', $text); // Remove event handlers
+
+        // Trim whitespace
+        return trim($text);
+    }
+}

--- a/Plugin/Quote/SanitizeAddressPlugin.php
+++ b/Plugin/Quote/SanitizeAddressPlugin.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Copyright (c) Address Zen
+ *
+ * Quote Address Sanitization Plugin
+ *
+ * This plugin intercepts quote address data (used in checkout) and sanitizes
+ * the city field to prevent XSS attacks by stripping HTML/script tags.
+ *
+ * @package Addresszen_Lookup
+ * @author Address Zen <support@addresszen.com>
+ * @copyright Address Zen
+ * @license MIT https://opensource.org/licenses/MIT
+ * @link https://addresszen.com
+ */
+
+namespace Addresszen\Lookup\Plugin\Quote;
+
+use Magento\Quote\Model\Quote\Address;
+
+/**
+ * Plugin to sanitize address data in checkout
+ *
+ * Intercepts the setCity method to strip HTML tags and prevent XSS attacks.
+ * This is necessary because checkout uses REST API/GraphQL which bypasses
+ * the standard EAV input_filter attribute setting.
+ */
+class SanitizeAddressPlugin
+{
+    /**
+     * Sanitize city field before setting it on quote address
+     *
+     * This plugin intercepts the setCity() method call and strips any HTML/XML
+     * tags from the input to prevent stored XSS attacks.
+     *
+     * @param Address $subject The quote address object
+     * @param string|null $city The city value being set
+     * @return array Modified arguments for the original method
+     */
+    public function beforeSetCity(Address $subject, $city)
+    {
+        if ($city !== null && is_string($city)) {
+            // Remove script/style tags AND their content
+            $city = preg_replace('/<script\b[^>]*>(.*?)<\/script>/is', '', $city);
+            $city = preg_replace('/<style\b[^>]*>(.*?)<\/style>/is', '', $city);
+
+            // Strip all remaining HTML and PHP tags
+            $city = strip_tags($city);
+
+            // Remove any remaining JavaScript-like patterns
+            $city = preg_replace('/javascript:/i', '', $city);
+            $city = preg_replace('/on\w+\s*=/i', '', $city); // Remove event handlers like onclick=
+
+            // Trim whitespace
+            $city = trim($city);
+        }
+
+        return [$city];
+    }
+
+    /**
+     * Sanitize all address data before saving
+     *
+     * This provides an additional layer of protection by sanitizing
+     * all address fields that might contain user input.
+     *
+     * @param Address $subject The quote address object
+     * @return void
+     */
+    public function beforeBeforeSave(Address $subject)
+    {
+        // Sanitize city if it exists
+        $city = $subject->getCity();
+        if ($city !== null && is_string($city)) {
+            $subject->setCity($this->sanitizeText($city));
+        }
+
+        // Also sanitize other text fields that might be vulnerable
+        $street = $subject->getStreet();
+        if (is_array($street)) {
+            $sanitizedStreet = array_map(function($line) {
+                return is_string($line) ? $this->sanitizeText($line) : $line;
+            }, $street);
+            $subject->setStreet($sanitizedStreet);
+        }
+
+        // Sanitize company name
+        $company = $subject->getCompany();
+        if ($company !== null && is_string($company)) {
+            $subject->setCompany($this->sanitizeText($company));
+        }
+    }
+
+    /**
+     * Sanitize text by removing HTML tags and JavaScript
+     *
+     * @param string $text
+     * @return string
+     */
+    private function sanitizeText($text)
+    {
+        if (!is_string($text)) {
+            return $text;
+        }
+
+        // Remove script/style tags AND their content
+        $text = preg_replace('/<script\b[^>]*>(.*?)<\/script>/is', '', $text);
+        $text = preg_replace('/<style\b[^>]*>(.*?)<\/style>/is', '', $text);
+
+        // Strip all remaining HTML and PHP tags
+        $text = strip_tags($text);
+
+        // Remove any remaining JavaScript-like patterns
+        $text = preg_replace('/javascript:/i', '', $text);
+        $text = preg_replace('/on\w+\s*=/i', '', $text); // Remove event handlers
+
+        // Trim whitespace
+        return trim($text);
+    }
+}

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Copyright (c) Address Zen
+ *
+ * Address Zen Magento Extension
+ *
+ * This extension provides US address search functionality for Magento 2
+ * checkout and customer address forms using the Address Zen API.
+ *
+ * @package Addresszen_Lookup
+ * @author Address Zen <support@addresszen.com>
+ * @copyright Address Zen
+ * @license MIT https://opensource.org/licenses/MIT
+ * @link https://addresszen.com
+ */
+
+namespace Addresszen\Lookup\Setup;
+
+use Magento\Framework\Setup\UpgradeDataInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Customer\Setup\CustomerSetupFactory;
+use Magento\Customer\Api\AddressMetadataInterface;
+
+/**
+ * Upgrade Data Script
+ *
+ * This script updates the city attribute validation rules to allow
+ * real-world city names with periods (e.g., "St. Louis"), numbers,
+ * ampersands, and other common punctuation marks.
+ *
+ * The default Magento validation regex is too restrictive and only
+ * allows letters and spaces, which fails for cities like:
+ * - St. Louis
+ * - St. Petersburg
+ * - Winston-Salem
+ * - 29 Palms
+ *
+ * This override implements a more permissive pattern while maintaining
+ * security and data integrity.
+ */
+class UpgradeData implements UpgradeDataInterface
+{
+    /**
+     * @var CustomerSetupFactory
+     */
+    protected $customerSetupFactory;
+
+    /**
+     * Constructor
+     *
+     * @param CustomerSetupFactory $customerSetupFactory
+     */
+    public function __construct(CustomerSetupFactory $customerSetupFactory)
+    {
+        $this->customerSetupFactory = $customerSetupFactory;
+    }
+
+    /**
+     * Upgrade data for the module
+     *
+     * @param ModuleDataSetupInterface $setup
+     * @param ModuleContextInterface $context
+     * @return void
+     */
+    public function upgrade(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
+    {
+        // Apply city validation override for version 3.1.3
+        if (version_compare($context->getVersion(), '3.1.3', '<')) {
+            $this->updateCityValidationRules($setup);
+        }
+    }
+
+    /**
+     * Update city attribute validation rules
+     *
+     * Overrides the default city validation regex to allow:
+     * - Letters (A-Z, a-z)
+     * - Numbers (0-9)
+     * - Spaces
+     * - Hyphens (-)
+     * - Periods/dots (.)
+     * - Ampersands (&)
+     * - Parentheses ()
+     * - Apostrophes (')
+     *
+     * This allows for real-world city names like:
+     * - "St. Louis", "St. Petersburg" (periods in abbreviations)
+     * - "Winston-Salem" (hyphens)
+     * - "29 Palms" (numbers)
+     * - "O'Fallon" (apostrophes)
+     *
+     * @param ModuleDataSetupInterface $setup
+     * @return void
+     */
+    protected function updateCityValidationRules(ModuleDataSetupInterface $setup)
+    {
+        $setup->startSetup();
+
+        $customerSetup = $this->customerSetupFactory->create(['setup' => $setup]);
+
+        // Get the address entity type ID
+        $addressEntityTypeId = $customerSetup->getEntityTypeId(
+            AddressMetadataInterface::ENTITY_TYPE_ADDRESS
+        );
+
+        // Get the current city attribute configuration
+        $cityAttribute = $customerSetup->getAttribute($addressEntityTypeId, 'city');
+
+        if ($cityAttribute) {
+            // Get existing validation rules
+            $validateRules = $cityAttribute['validate_rules'] ?? [];
+
+            // Decode JSON if it's stored as a string
+            if (is_string($validateRules)) {
+                $validateRules = json_decode($validateRules, true) ?: [];
+            }
+
+            // Remove restrictive validation rules
+            // Keep only max_text_length and min_text_length
+            $validateRules = [
+                'max_text_length' => 255,
+                'min_text_length' => 1,
+                'input_validation' => 'length' // Only validate length, not character type
+            ];
+
+            // Update the attribute with relaxed validation rules
+            // This removes the validate-alpha restriction
+            // input_filter strips HTML tags to prevent XSS attacks
+            $customerSetup->updateAttribute(
+                $addressEntityTypeId,
+                'city',
+                [
+                    'validate_rules' => json_encode($validateRules, JSON_UNESCAPED_SLASHES),
+                    'frontend_class' => null, // Remove any frontend validation classes
+                    'input_filter' => 'striptags' // Strip HTML/XML tags for XSS protection
+                ]
+            );
+        }
+
+        $setup->endSetup();
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright (c) Address Zen
+ *
+ * Dependency Injection Configuration
+ *
+ * This file configures plugins to sanitize address data and prevent XSS attacks
+ * in checkout and address management forms.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <!-- Plugin to sanitize quote address data (checkout) -->
+    <type name="Magento\Quote\Model\Quote\Address">
+        <plugin name="addresszen_sanitize_quote_address"
+                type="Addresszen\Lookup\Plugin\Quote\SanitizeAddressPlugin"
+                sortOrder="10"/>
+    </type>
+
+    <!-- Plugin to sanitize customer address data -->
+    <type name="Magento\Customer\Model\Address">
+        <plugin name="addresszen_sanitize_customer_address"
+                type="Addresszen\Lookup\Plugin\Customer\SanitizeAddressPlugin"
+                sortOrder="10"/>
+    </type>
+</config>


### PR DESCRIPTION
…alidation rules

Add sanitization plugins for quote and customer address data to prevent XSS attacks by stripping HTML/script tags from city, street, and company fields. Update city attribute validation to allow real-world city names with periods, hyphens, numbers, and apostrophes (e.g., "St. Louis", "Winston-Salem", "29 Palms"). Configure dependency injection for address sanitization plugins.